### PR TITLE
Add new deferred_ttl job attribute + Cleanup method for DeferredJobRegistry

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -69,6 +69,8 @@ results are kept. Expired jobs will be automatically deleted. Defaults to 500 se
 * `ttl` specifies the maximum queued time (in seconds) of the job before it's discarded.
   This argument defaults to `None` (infinite TTL).
 * `failure_ttl` specifies how long failed jobs are kept (defaults to 1 year)
+* `deferred_ttl` specifies how long deferred jobs (jobs have have `depends_on` set) wait 
+  before being considered failed. Defaults to infinite.
 * `depends_on` specifies another job (or job id) that must complete before this
   job will be queued.
 * `job_id` allows you to manually specify this job's `job_id`

--- a/docs/docs/jobs.md
+++ b/docs/docs/jobs.md
@@ -59,6 +59,8 @@ The keyword arguments accepted by `create()` are:
 * `ttl` specifies the maximum queued time (in seconds) of the job before it's discarded.
   This argument defaults to `None` (infinite TTL).
 * `failure_ttl` specifies how long (in seconds) failed jobs are kept (defaults to 1 year)
+* `deferred_ttl` specifies how long deferred jobs (jobs have have `depends_on` set) wait 
+  before being considered failed. Defaults to infinite.
 * `depends_on` specifies another job (or job id) that must complete before this
   job will be queued.
 * `id` allows you to manually specify this job's id

--- a/rq/decorators.py
+++ b/rq/decorators.py
@@ -17,7 +17,7 @@ class job(object):  # noqa
     def __init__(self, queue, connection=None, timeout=None,
                  result_ttl=DEFAULT_RESULT_TTL, ttl=None,
                  queue_class=None, depends_on=None, at_front=None, meta=None,
-                 description=None, failure_ttl=None, retry=None):
+                 description=None, failure_ttl=None, retry=None, deferred_ttl=None):
         """A decorator that adds a ``delay`` method to the decorated function,
         which in turn creates a RQ job when called. Accepts a required
         ``queue`` argument that can be either a ``Queue`` instance or a string
@@ -40,6 +40,7 @@ class job(object):  # noqa
         self.at_front = at_front
         self.description = description
         self.failure_ttl = failure_ttl
+        self.deferred_ttl = deferred_ttl
         self.retry = retry
 
     def __call__(self, f):
@@ -65,6 +66,6 @@ class job(object):  # noqa
                                       timeout=self.timeout, result_ttl=self.result_ttl,
                                       ttl=self.ttl, depends_on=depends_on, job_id=job_id, at_front=at_front,
                                       meta=self.meta, description=self.description, failure_ttl=self.failure_ttl,
-                                      retry=self.retry)
+                                      retry=self.retry, deferred_ttl=self.deferred_ttl)
         f.delay = delay
         return f

--- a/rq/job.py
+++ b/rq/job.py
@@ -82,7 +82,7 @@ class Job(object):
     def create(cls, func, args=None, kwargs=None, connection=None,
                result_ttl=None, ttl=None, status=None, description=None,
                depends_on=None, timeout=None, id=None, origin=None, meta=None,
-               failure_ttl=None, serializer=None):
+               failure_ttl=None, serializer=None, deferred_ttl=None):
         """Creates a new Job instance for the given function, arguments, and
         keyword arguments.
         """
@@ -124,6 +124,7 @@ class Job(object):
         job.description = description or job.get_call_string()
         job.result_ttl = parse_timeout(result_ttl)
         job.failure_ttl = parse_timeout(failure_ttl)
+        job.deferred_ttl = parse_timeout(deferred_ttl)
         job.ttl = parse_timeout(ttl)
         job.timeout = parse_timeout(timeout)
         job._status = status
@@ -351,6 +352,7 @@ class Job(object):
         self.timeout = None
         self.result_ttl = None
         self.failure_ttl = None
+        self.deferred_ttl = None
         self.ttl = None
         self.worker_name = None
         self._status = None
@@ -505,6 +507,7 @@ class Job(object):
         self.timeout = parse_timeout(obj.get('timeout')) if obj.get('timeout') else None
         self.result_ttl = int(obj.get('result_ttl')) if obj.get('result_ttl') else None  # noqa
         self.failure_ttl = int(obj.get('failure_ttl')) if obj.get('failure_ttl') else None  # noqa
+        self.deferred_ttl = int(obj.get('deferred_ttl')) if obj.get('deferred_ttl') else None  # noqa
         self._status = obj.get('status').decode() if obj.get('status') else None
 
         dep_ids = obj.get('dependency_ids')
@@ -579,6 +582,8 @@ class Job(object):
             obj['result_ttl'] = self.result_ttl
         if self.failure_ttl is not None:
             obj['failure_ttl'] = self.failure_ttl
+        if self.deferred_ttl is not None:
+            obj['deferred_ttl'] = self.deferred_ttl
         if self._status is not None:
             obj['status'] = self._status
         if self._dependency_ids:
@@ -835,7 +840,7 @@ class Job(object):
         registry = DeferredJobRegistry(self.origin,
                                        connection=self.connection,
                                        job_class=self.__class__)
-        registry.add(self, pipeline=pipeline)
+        registry.add(self, pipeline=pipeline, ttl=self.deferred_ttl)
 
         connection = pipeline if pipeline is not None else self.connection
 

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -280,7 +280,8 @@ class Queue(object):
     def create_job(self, func, args=None, kwargs=None, timeout=None,
                    result_ttl=None, ttl=None, failure_ttl=None,
                    description=None, depends_on=None, job_id=None,
-                   meta=None, status=JobStatus.QUEUED, retry=None):
+                   meta=None, status=JobStatus.QUEUED, retry=None,
+                   deferred_ttl=None):
         """Creates a job based on parameters given."""
         timeout = parse_timeout(timeout)
 
@@ -291,6 +292,7 @@ class Queue(object):
 
         result_ttl = parse_timeout(result_ttl)
         failure_ttl = parse_timeout(failure_ttl)
+        deferred_ttl = parse_timeout(deferred_ttl)
 
         ttl = parse_timeout(ttl)
         if ttl is not None and ttl <= 0:
@@ -301,7 +303,8 @@ class Queue(object):
             result_ttl=result_ttl, ttl=ttl, failure_ttl=failure_ttl,
             status=status, description=description,
             depends_on=depends_on, timeout=timeout, id=job_id,
-            origin=self.name, meta=meta, serializer=self.serializer
+            origin=self.name, meta=meta, serializer=self.serializer,
+            deferred_ttl=deferred_ttl
         )
 
         if retry:
@@ -313,7 +316,7 @@ class Queue(object):
     def enqueue_call(self, func, args=None, kwargs=None, timeout=None,
                      result_ttl=None, ttl=None, failure_ttl=None,
                      description=None, depends_on=None, job_id=None,
-                     at_front=False, meta=None, retry=None):
+                     at_front=False, meta=None, retry=None, deferred_ttl=None):
         """Creates a job to represent the delayed function call and enqueues
         it.
 nd
@@ -326,7 +329,7 @@ nd
             func, args=args, kwargs=kwargs, result_ttl=result_ttl, ttl=ttl,
             failure_ttl=failure_ttl, description=description, depends_on=depends_on,
             job_id=job_id, meta=meta, status=JobStatus.QUEUED, timeout=timeout,
-            retry=retry
+            retry=retry, deferred_ttl=deferred_ttl
         )
 
         # If a _dependent_ job depends on any unfinished job, register all the
@@ -396,6 +399,7 @@ nd
         result_ttl = kwargs.pop('result_ttl', None)
         ttl = kwargs.pop('ttl', None)
         failure_ttl = kwargs.pop('failure_ttl', None)
+        deferred_ttl = kwargs.pop('deferred_ttl', None)
         depends_on = kwargs.pop('depends_on', None)
         job_id = kwargs.pop('job_id', None)
         at_front = kwargs.pop('at_front', False)
@@ -407,31 +411,32 @@ nd
             args = kwargs.pop('args', None)
             kwargs = kwargs.pop('kwargs', None)
 
-        return (f, timeout, description, result_ttl, ttl, failure_ttl,
+        return (f, timeout, description, result_ttl, ttl, failure_ttl, deferred_ttl,
                 depends_on, job_id, at_front, meta, retry, args, kwargs)
 
     def enqueue(self, f, *args, **kwargs):
         """Creates a job to represent the delayed function call and enqueues it."""
 
-        (f, timeout, description, result_ttl, ttl, failure_ttl,
+        (f, timeout, description, result_ttl, ttl, failure_ttl, deferred_ttl,
          depends_on, job_id, at_front, meta, retry, args, kwargs) = Queue.parse_args(f, *args, **kwargs)
 
         return self.enqueue_call(
             func=f, args=args, kwargs=kwargs, timeout=timeout,
             result_ttl=result_ttl, ttl=ttl, failure_ttl=failure_ttl,
             description=description, depends_on=depends_on, job_id=job_id,
-            at_front=at_front, meta=meta, retry=retry
+            at_front=at_front, meta=meta, retry=retry, deferred_ttl=deferred_ttl
         )
 
     def enqueue_at(self, datetime, f, *args, **kwargs):
         """Schedules a job to be enqueued at specified time"""
 
-        (f, timeout, description, result_ttl, ttl, failure_ttl,
+        (f, timeout, description, result_ttl, ttl, failure_ttl, deferred_ttl,
          depends_on, job_id, at_front, meta, retry, args, kwargs) = Queue.parse_args(f, *args, **kwargs)
         job = self.create_job(f, status=JobStatus.SCHEDULED, args=args, kwargs=kwargs,
                               timeout=timeout, result_ttl=result_ttl, ttl=ttl,
                               failure_ttl=failure_ttl, description=description,
-                              depends_on=depends_on, job_id=job_id, meta=meta, retry=retry)
+                              depends_on=depends_on, job_id=job_id, meta=meta,
+                              retry=retry, deferred_ttl=deferred_ttl)
 
         return self.schedule_job(job, datetime)
 

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -243,12 +243,47 @@ class DeferredJobRegistry(BaseRegistry):
     """
     key_template = 'rq:deferred:{0}'
 
-    def cleanup(self):
-        """This method is only here to prevent errors because this method is
-        automatically called by `count()` and `get_job_ids()` methods
-        implemented in BaseRegistry."""
-        pass
+    def cleanup(self, timestamp=None):
+        """Remove expired jobs from registry and add them to FailedJobRegistry.
 
+        Removes jobs with an expiry time earlier than timestamp, specified as
+        seconds since the Unix epoch. timestamp defaults to call time if
+        unspecified. Removed jobs are added to the global failed job queue.
+        """
+        score = timestamp if timestamp is not None else current_timestamp()
+        job_ids = self.get_expired_job_ids(score)
+
+        if job_ids:
+            failed_job_registry = FailedJobRegistry(self.name, self.connection)
+
+            with self.connection.pipeline() as pipeline:
+                for job_id in job_ids:
+                    try:
+                        job = self.job_class.fetch(job_id,
+                                                   connection=self.connection)
+                    except NoSuchJobError:
+                        continue
+
+                    job.set_status(JobStatus.FAILED)
+                    job.exc_info = "Expired in DeferredJobRegistry, moved to FailedJobRegistry at %s" % datetime.now()
+                    job.save(pipeline=pipeline, include_meta=False)
+                    job.cleanup(ttl=-1, pipeline=pipeline)
+                    failed_job_registry.add(job, job.failure_ttl)
+
+                pipeline.zremrangebyscore(self.key, 0, score)
+                pipeline.execute()
+
+        return job_ids
+
+    def add(self, job, ttl=None, pipeline=None, xx=False):
+        """
+        Adds a job to a registry with expiry time of now + ttl.
+        Defaults to -1 (never expire).
+        """
+        if ttl is None:
+            ttl = -1
+
+        return super(DeferredJobRegistry, self).add(job, ttl, pipeline, xx)
 
 class ScheduledJobRegistry(BaseRegistry):
     """
@@ -315,7 +350,7 @@ class ScheduledJobRegistry(BaseRegistry):
 
 
 def clean_registries(queue):
-    """Cleans StartedJobRegistry, FinishedJobRegistry and FailedJobRegistry of a queue."""
+    """Cleans StartedJobRegistry, FinishedJobRegistry, FailedJobRegistry, and DeferredJobRegistry of a queue."""
     registry = FinishedJobRegistry(name=queue.name,
                                    connection=queue.connection,
                                    job_class=queue.job_class)
@@ -326,6 +361,11 @@ def clean_registries(queue):
     registry.cleanup()
 
     registry = FailedJobRegistry(name=queue.name,
+                                 connection=queue.connection,
+                                 job_class=queue.job_class)
+    registry.cleanup()
+
+    registry = DeferredJobRegistry(name=queue.name,
                                  connection=queue.connection,
                                  job_class=queue.job_class)
     registry.cleanup()

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -222,6 +222,20 @@ class TestDecorator(RQTestCase):
         result = hello.delay()
         self.assertEqual(result.failure_ttl, 10)
 
+    def test_decorator_custom_deferred_ttl(self):
+        """Ensure that passing in deferred_ttl to the decorator sets the
+        deferred_ttl on the job
+        """
+        # Ensure default
+        result = decorated_job.delay(1, 2)
+        self.assertEqual(result.deferred_ttl, None)
+
+        @job('default', deferred_ttl=10)
+        def hello():
+            return 'Why hello'
+        result = hello.delay()
+        self.assertEqual(result.deferred_ttl, 10)
+
     def test_decorator_custom_retry(self):
         """ Ensure that passing in retry to the decorator sets the
         retry on the job

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -403,6 +403,18 @@ class TestJob(RQTestCase):
         Job.fetch(job.id, connection=self.testconn)
         self.assertEqual(job.failure_ttl, None)
 
+    def test_deferred_ttl_is_persisted(self):
+        """Ensure job.deferred_ttl is set and restored properly"""
+        job = Job.create(func=fixtures.say_hello, args=('Lionel',), deferred_ttl=15)
+        job.save()
+        Job.fetch(job.id, connection=self.testconn)
+        self.assertEqual(job.deferred_ttl, 15)
+
+        job = Job.create(func=fixtures.say_hello, args=('Lionel',))
+        job.save()
+        Job.fetch(job.id, connection=self.testconn)
+        self.assertEqual(job.deferred_ttl, None)
+
     def test_description_is_persisted(self):
         """Ensure that job's custom description is set properly"""
         job = Job.create(func=fixtures.say_hello, args=('Lionel',),

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -303,6 +303,13 @@ class TestQueue(RQTestCase):
         job.refresh()
         self.assertEqual(job.failure_ttl, 10)
 
+    def test_enqueue_with_deferred_ttl(self):
+        """enqueue() properly sets job.deferred_ttl"""
+        q = Queue()
+        job = q.enqueue(say_hello, deferred_ttl=10)
+        job.refresh()
+        self.assertEqual(job.deferred_ttl, 10)
+
     def test_job_timeout(self):
         """Timeout can be passed via job_timeout argument"""
         queue = Queue()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -292,6 +292,24 @@ class TestDeferredRegistry(RQTestCase):
                    self.testconn.zrange(self.registry.key, 0, -1)]
         self.assertEqual(job_ids, [job.id])
 
+    def test_add_with_deferred_ttl(self):
+        """Job TTL defaults to +inf"""
+        queue = Queue(connection=self.testconn)
+        job = queue.enqueue(say_hello)
+
+        key = self.registry.key
+
+        self.registry.add(job)
+        score = self.testconn.zscore(key, job.id)
+        self.assertEqual(score, float('inf'))
+
+        timestamp = current_timestamp()
+        ttl = 5
+        self.registry.add(job, ttl=ttl)
+        score = self.testconn.zscore(key, job.id)
+        self.assertLess(score, timestamp + ttl + 2)
+        self.assertGreater(score, timestamp + ttl - 2)
+
     def test_register_dependency(self):
         """Ensure job creation and deletion works with DeferredJobRegistry."""
         queue = Queue(connection=self.testconn)
@@ -304,6 +322,26 @@ class TestDeferredRegistry(RQTestCase):
         # When deleted, job removes itself from DeferredJobRegistry
         job2.delete()
         self.assertEqual(registry.get_job_ids(), [])
+
+    def test_cleanup_moves_jobs_to_failed_job_registry(self):
+        """Moving expired jobs to FailedJobRegistry."""
+        queue = Queue(connection=self.testconn)
+        failed_job_registry = FailedJobRegistry(connection=self.testconn)
+        job = queue.enqueue(say_hello)
+
+        self.testconn.zadd(self.registry.key, {job.id: 2})
+
+        # Job has not been moved to FailedJobRegistry
+        self.registry.cleanup(1)
+        self.assertNotIn(job, failed_job_registry)
+        self.assertIn(job, self.registry)
+
+        self.registry.cleanup()
+        self.assertIn(job.id, failed_job_registry)
+        self.assertNotIn(job, self.registry)
+        job.refresh()
+        self.assertEqual(job.get_status(), JobStatus.FAILED)
+        self.assertTrue(job.exc_info)  # explanation is written to exc_info
 
 
 class TestFailedJobRegistry(RQTestCase):


### PR DESCRIPTION
This PR adds a new `deferred_ttl` attribute to RQ jobs that specify the amount of time they are able to spend deferred in the `DeferredJobRegistry` before being cleaned up. By default, this value is None, which means that these jobs will indefinitely stay in the registry (current behavior)